### PR TITLE
Refactor machine alpha into modular features

### DIFF
--- a/cpp_features/close_to_edge_distance_frac.cpp
+++ b/cpp_features/close_to_edge_distance_frac.cpp
@@ -1,0 +1,62 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <algorithm>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_close_to_edge_distance_frac(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                          const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price") || !cubes_map.contains("interval_high") || !cubes_map.contains("interval_low")) {
+        throw std::runtime_error("cubes_map must contain 'last_price','interval_high','interval_low'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto high_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_high"]);
+    auto low_arr   = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_low"]);
+    auto pbuf = price_arr.request();
+    auto hbuf = high_arr.request();
+    auto lbuf = low_arr.request();
+    if (pbuf.ndim != 3 || hbuf.ndim != 3 || lbuf.ndim != 3) {
+        throw std::runtime_error("inputs must be 3D arrays");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    const float* high_ptr  = static_cast<float*>(hbuf.ptr);
+    const float* low_ptr   = static_cast<float*>(lbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            float close = price_ptr[base + d2 - 1];
+            float high = high_ptr[base];
+            float low  = low_ptr[base];
+            for (ssize_t t = 1; t < d2; ++t) {
+                float h = high_ptr[base + t];
+                float l = low_ptr[base + t];
+                if (std::isfinite(h) && h > high) high = h;
+                if (std::isfinite(l) && l < low)  low  = l;
+            }
+            float range = high - low;
+            float val = (range > 0.0f)
+                ? std::min(close - low, high - close) / range
+                : std::numeric_limits<float>::quiet_NaN();
+            res_ptr[i * d1 + j] = std::isfinite(val) ? val : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_close_to_edge_distance_frac(py::module& m) {
+    m.def("cube2mat_close_to_edge_distance_frac", &cube2mat_close_to_edge_distance_frac,
+          py::arg("result"), py::arg("cubes_map"),
+          "Distance of last close to session edges normalized by range.");
+}

--- a/cpp_features/common.hpp
+++ b/cpp_features/common.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <limits>
+#include <cmath>
+
+inline float gini_coeff(std::vector<float>& x) {
+    const ssize_t n = static_cast<ssize_t>(x.size());
+    if (n < 2) return std::numeric_limits<float>::quiet_NaN();
+    double sum = 0.0;
+    for (float v : x) sum += v;
+    if (!(sum > 0.0)) return std::numeric_limits<float>::quiet_NaN();
+    std::sort(x.begin(), x.end());
+    double g = 0.0;
+    for (ssize_t k = 0; k < n; ++k) {
+        g += (static_cast<double>(n - k) - 0.5) * x[k];
+    }
+    g = 1.0 - 2.0 * g / (static_cast<double>(n) * sum);
+    if (!std::isfinite(g)) return std::numeric_limits<float>::quiet_NaN();
+    if (g < 0.0) g = 0.0; else if (g > 1.0) g = 1.0;
+    return static_cast<float>(g);
+}
+
+inline float entropy_concentration(const std::vector<float>& x) {
+    const ssize_t m = static_cast<ssize_t>(x.size());
+    double tot = 0.0;
+    for (float v : x) tot += v;
+    if (m < 2 || !(tot > 0.0)) return std::numeric_limits<float>::quiet_NaN();
+    double H = 0.0;
+    for (float v : x) {
+        double p = static_cast<double>(v) / tot;
+        if (p > 0.0) H -= p * std::log(p);
+    }
+    double Hmax = std::log(static_cast<double>(m));
+    if (!(Hmax > 0.0)) return std::numeric_limits<float>::quiet_NaN();
+    double conc = 1.0 - H / Hmax;
+    if (!std::isfinite(conc)) return std::numeric_limits<float>::quiet_NaN();
+    if (conc < 0.0) conc = 0.0; else if (conc > 1.0) conc = 1.0;
+    return static_cast<float>(conc);
+}

--- a/cpp_features/end_position_in_range.cpp
+++ b/cpp_features/end_position_in_range.cpp
@@ -1,0 +1,60 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_end_position_in_range(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                    const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price") || !cubes_map.contains("interval_high") || !cubes_map.contains("interval_low")) {
+        throw std::runtime_error("cubes_map must contain 'last_price','interval_high','interval_low'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto high_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_high"]);
+    auto low_arr   = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_low"]);
+    auto pbuf = price_arr.request();
+    auto hbuf = high_arr.request();
+    auto lbuf = low_arr.request();
+    if (pbuf.ndim != 3 || hbuf.ndim != 3 || lbuf.ndim != 3) {
+        throw std::runtime_error("inputs must be 3D arrays");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    const float* high_ptr  = static_cast<float*>(hbuf.ptr);
+    const float* low_ptr   = static_cast<float*>(lbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            float close = price_ptr[base + d2 - 1];
+            float high = high_ptr[base];
+            float low  = low_ptr[base];
+            for (ssize_t t = 1; t < d2; ++t) {
+                float h = high_ptr[base + t];
+                float l = low_ptr[base + t];
+                if (std::isfinite(h) && h > high) high = h;
+                if (std::isfinite(l) && l < low)  low  = l;
+            }
+            float range = high - low;
+            float val = (range > 0.0f) ? (close - low) / range
+                                       : std::numeric_limits<float>::quiet_NaN();
+            res_ptr[i * d1 + j] = std::isfinite(val) ? val : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_end_position_in_range(py::module& m) {
+    m.def("cube2mat_end_position_in_range", &cube2mat_end_position_in_range,
+          py::arg("result"), py::arg("cubes_map"),
+          "Position of last close within session range.");
+}

--- a/cpp_features/gini_absret.cpp
+++ b/cpp_features/gini_absret.cpp
@@ -1,0 +1,60 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "common.hpp"
+#include <cmath>
+#include <limits>
+#include <vector>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_gini_absret(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                          const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match last_price leading dims");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> vals;
+            vals.reserve(d2 > 0 ? d2 - 1 : 0);
+            float prev = price_ptr[base];
+            bool prev_valid = std::isfinite(prev) && prev > 0.0f;
+            for (ssize_t t = 1; t < d2; ++t) {
+                float curr = price_ptr[base + t];
+                bool curr_valid = std::isfinite(curr) && curr > 0.0f;
+                if (prev_valid && curr_valid) {
+                    float r = std::log(curr / prev);
+                    float v = std::fabs(r);
+                    if (std::isfinite(v) && v >= 0.0f) vals.push_back(v);
+                }
+                prev = curr;
+                prev_valid = curr_valid;
+            }
+            res_ptr[i * d1 + j] = gini_coeff(vals);
+        }
+    }
+}
+
+void bind_gini_absret(py::module& m) {
+    m.def("cube2mat_gini_absret", &cube2mat_gini_absret,
+          py::arg("result"), py::arg("cubes_map"),
+          "Gini concentration of absolute log returns.");
+}

--- a/cpp_features/intraday_max_drawdown_close.cpp
+++ b/cpp_features/intraday_max_drawdown_close.cpp
@@ -1,0 +1,52 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_intraday_max_drawdown_close(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                          const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            float run_max = price_ptr[base];
+            float max_dd = 0.0f;
+            for (ssize_t t = 1; t < d2; ++t) {
+                float c = price_ptr[base + t];
+                if (std::isfinite(c)) {
+                    if (c > run_max) run_max = c;
+                    float dd = (run_max > 0.0f) ? (run_max - c) / run_max : 0.0f;
+                    if (dd > max_dd) max_dd = dd;
+                }
+            }
+            res_ptr[i * d1 + j] = max_dd;
+        }
+    }
+}
+
+void bind_intraday_max_drawdown_close(py::module& m) {
+    m.def("cube2mat_intraday_max_drawdown_close", &cube2mat_intraday_max_drawdown_close,
+          py::arg("result"), py::arg("cubes_map"),
+          "Maximum drawdown fraction from close path.");
+}

--- a/cpp_features/katz_fd_close.cpp
+++ b/cpp_features/katz_fd_close.cpp
@@ -1,0 +1,71 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <cmath>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_katz_fd_close(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                            const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            float first = price_ptr[base];
+            if (!std::isfinite(first)) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double L = 0.0;
+            double dmax = 0.0;
+            float prev = first;
+            bool prev_valid = std::isfinite(prev);
+            for (ssize_t t = 1; t < d2; ++t) {
+                float c = price_ptr[base + t];
+                bool cv = std::isfinite(c);
+                if (prev_valid && cv) {
+                    double step = std::fabs(static_cast<double>(c - prev));
+                    L += step;
+                    double dist = std::fabs(static_cast<double>(c - first));
+                    if (dist > dmax) dmax = dist;
+                }
+                prev = c;
+                prev_valid = cv;
+            }
+            if (!(L > 0.0) || !(dmax > 0.0)) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double n = static_cast<double>(d2 - 1);
+            double D = std::log10(n) / (std::log10(n) + std::log10(dmax / L));
+            res_ptr[i * d1 + j] = std::isfinite(D) ? static_cast<float>(D)
+                                                   : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_katz_fd_close(py::module& m) {
+    m.def("cube2mat_katz_fd_close", &cube2mat_katz_fd_close,
+          py::arg("result"), py::arg("cubes_map"),
+          "Katz fractal dimension of close path.");
+}

--- a/cpp_features/n_entropy_concentration.cpp
+++ b/cpp_features/n_entropy_concentration.cpp
@@ -1,0 +1,50 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "common.hpp"
+#include <limits>
+#include <vector>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_n_entropy_concentration(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                      const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_volume")) {
+        throw std::runtime_error("cubes_map must contain 'interval_volume'");
+    }
+    auto vol_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto vbuf = vol_arr.request();
+    if (vbuf.ndim != 3) {
+        throw std::runtime_error("interval_volume must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = vbuf.shape[0];
+    const ssize_t d1 = vbuf.shape[1];
+    const ssize_t d2 = vbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match volume leading dims");
+    }
+    const float* vol_ptr = static_cast<float*>(vbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> vals;
+            vals.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                if (std::isfinite(v) && v > 0.0f) vals.push_back(v);
+            }
+            res_ptr[i * d1 + j] = entropy_concentration(vals);
+        }
+    }
+}
+
+void bind_n_entropy_concentration(py::module& m) {
+    m.def("cube2mat_n_entropy_concentration", &cube2mat_n_entropy_concentration,
+          py::arg("result"), py::arg("cubes_map"),
+          "1 - normalized entropy of trade count distribution.");
+}

--- a/cpp_features/n_gini.cpp
+++ b/cpp_features/n_gini.cpp
@@ -1,0 +1,50 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "common.hpp"
+#include <vector>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_n_gini(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                     const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_volume")) {
+        throw std::runtime_error("cubes_map must contain 'interval_volume'");
+    }
+    auto vol_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto vbuf = vol_arr.request();
+    if (vbuf.ndim != 3) {
+        throw std::runtime_error("interval_volume must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = vbuf.shape[0];
+    const ssize_t d1 = vbuf.shape[1];
+    const ssize_t d2 = vbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match volume leading dims");
+    }
+    const float* vol_ptr = static_cast<float*>(vbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> vals;
+            vals.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                if (std::isfinite(v) && v >= 0.0f) vals.push_back(v);
+            }
+            res_ptr[i * d1 + j] = gini_coeff(vals);
+        }
+    }
+}
+
+void bind_n_gini(py::module& m) {
+    m.def("cube2mat_n_gini", &cube2mat_n_gini,
+          py::arg("result"), py::arg("cubes_map"),
+          "Gini index of trade count distribution.");
+}

--- a/cpp_features/oc_efficiency_over_range.cpp
+++ b/cpp_features/oc_efficiency_over_range.cpp
@@ -1,0 +1,63 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <cmath>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_oc_efficiency_over_range(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                       const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price") || !cubes_map.contains("interval_high") || !cubes_map.contains("interval_low")) {
+        throw std::runtime_error("cubes_map must contain 'last_price','interval_high','interval_low'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto high_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_high"]);
+    auto low_arr   = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_low"]);
+    auto pbuf = price_arr.request();
+    auto hbuf = high_arr.request();
+    auto lbuf = low_arr.request();
+    if (pbuf.ndim != 3 || hbuf.ndim != 3 || lbuf.ndim != 3) {
+        throw std::runtime_error("inputs must be 3D arrays");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    const float* high_ptr  = static_cast<float*>(hbuf.ptr);
+    const float* low_ptr   = static_cast<float*>(lbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            float open  = price_ptr[base];
+            float close = price_ptr[base + d2 - 1];
+            float high  = high_ptr[base];
+            float low   = low_ptr[base];
+            for (ssize_t t = 1; t < d2; ++t) {
+                float h = high_ptr[base + t];
+                float l = low_ptr[base + t];
+                if (std::isfinite(h) && h > high) high = h;
+                if (std::isfinite(l) && l < low)  low  = l;
+            }
+            float range = high - low;
+            float val = (range > 0.0f && std::isfinite(open) && std::isfinite(close))
+                ? std::fabs(close - open) / range
+                : std::numeric_limits<float>::quiet_NaN();
+            res_ptr[i * d1 + j] = std::isfinite(val) ? val : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_oc_efficiency_over_range(py::module& m) {
+    m.def("cube2mat_oc_efficiency_over_range", &cube2mat_oc_efficiency_over_range,
+          py::arg("result"), py::arg("cubes_map"),
+          "Absolute OC move normalized by session range.");
+}

--- a/cpp_features/parkinson_vol.cpp
+++ b/cpp_features/parkinson_vol.cpp
@@ -1,0 +1,60 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <cmath>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_parkinson_vol(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                            const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_high") || !cubes_map.contains("interval_low")) {
+        throw std::runtime_error("cubes_map must contain 'interval_high' and 'interval_low'");
+    }
+    auto high_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_high"]);
+    auto low_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_low"]);
+    auto hbuf = high_arr.request();
+    auto lbuf = low_arr.request();
+    if (hbuf.ndim != 3 || lbuf.ndim != 3) {
+        throw std::runtime_error("inputs must be 3D arrays");
+    }
+    const ssize_t d0 = hbuf.shape[0];
+    const ssize_t d1 = hbuf.shape[1];
+    const ssize_t d2 = hbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* high_ptr = static_cast<float*>(hbuf.ptr);
+    const float* low_ptr  = static_cast<float*>(lbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            float high = high_ptr[base];
+            float low  = low_ptr[base];
+            for (ssize_t t = 1; t < d2; ++t) {
+                float h = high_ptr[base + t];
+                float l = low_ptr[base + t];
+                if (std::isfinite(h) && h > high) high = h;
+                if (std::isfinite(l) && l < low)  low  = l;
+            }
+            if (std::isfinite(high) && std::isfinite(low) && high > 0.0f && low > 0.0f) {
+                double loghl = std::log(static_cast<double>(high / low));
+                double vol = std::sqrt((loghl * loghl) / (4.0 * std::log(2.0)));
+                res_ptr[i * d1 + j] = static_cast<float>(vol);
+            } else {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+            }
+        }
+    }
+}
+
+void bind_parkinson_vol(py::module& m) {
+    m.def("cube2mat_parkinson_vol", &cube2mat_parkinson_vol,
+          py::arg("result"), py::arg("cubes_map"),
+          "Parkinson volatility estimator using session high/low.");
+}

--- a/cpp_features/path_efficiency.cpp
+++ b/cpp_features/path_efficiency.cpp
@@ -1,0 +1,58 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <cmath>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_path_efficiency(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                              const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            float first = price_ptr[base];
+            float last  = price_ptr[base + d2 - 1];
+            double path = 0.0;
+            float prev = first;
+            bool prev_valid = std::isfinite(prev);
+            for (ssize_t t = 1; t < d2; ++t) {
+                float c = price_ptr[base + t];
+                bool cv = std::isfinite(c);
+                if (prev_valid && cv) path += std::fabs(static_cast<double>(c - prev));
+                prev = c;
+                prev_valid = cv;
+            }
+            double num = std::fabs(static_cast<double>(last - first));
+            float val = (path > 0.0) ? static_cast<float>(num / path)
+                                     : std::numeric_limits<float>::quiet_NaN();
+            res_ptr[i * d1 + j] = std::isfinite(val) ? val : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_path_efficiency(py::module& m) {
+    m.def("cube2mat_path_efficiency", &cube2mat_path_efficiency,
+          py::arg("result"), py::arg("cubes_map"),
+          "Path straightness of close series.");
+}

--- a/cpp_features/path_length_over_range.cpp
+++ b/cpp_features/path_length_over_range.cpp
@@ -1,0 +1,68 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <cmath>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_path_length_over_range(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                     const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price") || !cubes_map.contains("interval_high") || !cubes_map.contains("interval_low")) {
+        throw std::runtime_error("cubes_map must contain 'last_price','interval_high','interval_low'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto high_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_high"]);
+    auto low_arr   = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_low"]);
+    auto pbuf = price_arr.request();
+    auto hbuf = high_arr.request();
+    auto lbuf = low_arr.request();
+    if (pbuf.ndim != 3 || hbuf.ndim != 3 || lbuf.ndim != 3) {
+        throw std::runtime_error("inputs must be 3D arrays");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    const float* high_ptr  = static_cast<float*>(hbuf.ptr);
+    const float* low_ptr   = static_cast<float*>(lbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            double path = 0.0;
+            float prev = price_ptr[base];
+            bool prev_valid = std::isfinite(prev);
+            float high = high_ptr[base];
+            float low  = low_ptr[base];
+            for (ssize_t t = 1; t < d2; ++t) {
+                float c = price_ptr[base + t];
+                bool cv = std::isfinite(c);
+                if (prev_valid && cv) path += std::fabs(static_cast<double>(c - prev));
+                prev = c;
+                prev_valid = cv;
+                float h = high_ptr[base + t];
+                float l = low_ptr[base + t];
+                if (std::isfinite(h) && h > high) high = h;
+                if (std::isfinite(l) && l < low)  low  = l;
+            }
+            float range = high - low;
+            float val = (range > 0.0f) ? static_cast<float>(path / range)
+                                       : std::numeric_limits<float>::quiet_NaN();
+            res_ptr[i * d1 + j] = std::isfinite(val) ? val : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_path_length_over_range(py::module& m) {
+    m.def("cube2mat_path_length_over_range", &cube2mat_path_length_over_range,
+          py::arg("result"), py::arg("cubes_map"),
+          "Sum |Δclose| normalized by session range.");
+}

--- a/cpp_features/range_per_trade.cpp
+++ b/cpp_features/range_per_trade.cpp
@@ -1,0 +1,64 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <limits>
+#include <cmath>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_range_per_trade(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                              const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_high") || !cubes_map.contains("interval_low") || !cubes_map.contains("interval_volume")) {
+        throw std::runtime_error("cubes_map must contain 'interval_high','interval_low','interval_volume'");
+    }
+    auto high_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_high"]);
+    auto low_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_low"]);
+    auto vol_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto hbuf = high_arr.request();
+    auto lbuf = low_arr.request();
+    auto vbuf = vol_arr.request();
+    if (hbuf.ndim != 3 || lbuf.ndim != 3 || vbuf.ndim != 3) {
+        throw std::runtime_error("inputs must be 3D arrays");
+    }
+    const ssize_t d0 = hbuf.shape[0];
+    const ssize_t d1 = hbuf.shape[1];
+    const ssize_t d2 = hbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* high_ptr = static_cast<float*>(hbuf.ptr);
+    const float* low_ptr  = static_cast<float*>(lbuf.ptr);
+    const float* vol_ptr  = static_cast<float*>(vbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            float high = high_ptr[base];
+            float low  = low_ptr[base];
+            double volsum = 0.0;
+            for (ssize_t t = 1; t < d2; ++t) {
+                float h = high_ptr[base + t];
+                float l = low_ptr[base + t];
+                if (std::isfinite(h) && h > high) high = h;
+                if (std::isfinite(l) && l < low)  low  = l;
+            }
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                if (std::isfinite(v) && v > 0.0f) volsum += v;
+            }
+            float range = high - low;
+            res_ptr[i * d1 + j] = (volsum > 0.0 && range > 0.0f) ? static_cast<float>(range / volsum)
+                                                                 : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_range_per_trade(py::module& m) {
+    m.def("cube2mat_range_per_trade", &cube2mat_range_per_trade,
+          py::arg("result"), py::arg("cubes_map"),
+          "Session range divided by total trade count (volume proxy).");
+}

--- a/cpp_features/ret_skew.cpp
+++ b/cpp_features/ret_skew.cpp
@@ -1,0 +1,81 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <vector>
+#include <cmath>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_ret_skew(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                       const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match last_price leading dims");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<double> r;
+            r.reserve(d2 > 0 ? d2 - 1 : 0);
+            float prev = price_ptr[base];
+            bool prev_valid = std::isfinite(prev) && prev > 0.0f;
+            for (ssize_t t = 1; t < d2; ++t) {
+                float curr = price_ptr[base + t];
+                bool curr_valid = std::isfinite(curr) && curr > 0.0f;
+                if (prev_valid && curr_valid) {
+                    double rr = std::log(static_cast<double>(curr) / prev);
+                    if (std::isfinite(rr)) r.push_back(rr);
+                }
+                prev = curr;
+                prev_valid = curr_valid;
+            }
+            const ssize_t n = static_cast<ssize_t>(r.size());
+            if (n < 3) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double mean = 0.0;
+            for (double v : r) mean += v;
+            mean /= static_cast<double>(n);
+            double m2 = 0.0, m3 = 0.0;
+            for (double v : r) {
+                double d = v - mean;
+                m2 += d * d;
+                m3 += d * d * d;
+            }
+            double s2 = m2 / static_cast<double>(n - 1);
+            if (!(s2 > 0.0)) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double s = std::sqrt(s2);
+            double g1 = (static_cast<double>(n) * m3) /
+                        ((static_cast<double>(n - 1) * (n - 2)) * s * s * s);
+            res_ptr[i * d1 + j] = std::isfinite(g1) ? static_cast<float>(g1)
+                                                    : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_ret_skew(py::module& m) {
+    m.def("cube2mat_ret_skew", &cube2mat_ret_skew,
+          py::arg("result"), py::arg("cubes_map"),
+          "Sample-adjusted skewness of intraday log returns.");
+}

--- a/cpp_features/rv_entropy_concentration.cpp
+++ b/cpp_features/rv_entropy_concentration.cpp
@@ -1,0 +1,60 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "common.hpp"
+#include <vector>
+#include <limits>
+#include <cmath>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_rv_entropy_concentration(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                       const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match last_price leading dims");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> sqr;
+            sqr.reserve(d2 > 0 ? d2 - 1 : 0);
+            float prev = price_ptr[base];
+            bool prev_valid = std::isfinite(prev) && prev > 0.0f;
+            for (ssize_t t = 1; t < d2; ++t) {
+                float curr = price_ptr[base + t];
+                bool curr_valid = std::isfinite(curr) && curr > 0.0f;
+                if (prev_valid && curr_valid) {
+                    double r = std::log(static_cast<double>(curr) / prev);
+                    float v = static_cast<float>(r * r);
+                    if (std::isfinite(v) && v >= 0.0f) sqr.push_back(v);
+                }
+                prev = curr;
+                prev_valid = curr_valid;
+            }
+            res_ptr[i * d1 + j] = entropy_concentration(sqr);
+        }
+    }
+}
+
+void bind_rv_entropy_concentration(py::module& m) {
+    m.def("cube2mat_rv_entropy_concentration", &cube2mat_rv_entropy_concentration,
+          py::arg("result"), py::arg("cubes_map"),
+          "1 - normalized entropy of realized variance contributions.");
+}

--- a/cpp_features/rv_gini_concentration.cpp
+++ b/cpp_features/rv_gini_concentration.cpp
@@ -1,0 +1,60 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "common.hpp"
+#include <vector>
+#include <limits>
+#include <cmath>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_rv_gini_concentration(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                    const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match last_price leading dims");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> sqr;
+            sqr.reserve(d2 > 0 ? d2 - 1 : 0);
+            float prev = price_ptr[base];
+            bool prev_valid = std::isfinite(prev) && prev > 0.0f;
+            for (ssize_t t = 1; t < d2; ++t) {
+                float curr = price_ptr[base + t];
+                bool curr_valid = std::isfinite(curr) && curr > 0.0f;
+                if (prev_valid && curr_valid) {
+                    double r = std::log(static_cast<double>(curr) / prev);
+                    float v = static_cast<float>(r * r);
+                    if (std::isfinite(v) && v >= 0.0f) sqr.push_back(v);
+                }
+                prev = curr;
+                prev_valid = curr_valid;
+            }
+            res_ptr[i * d1 + j] = gini_coeff(sqr);
+        }
+    }
+}
+
+void bind_rv_gini_concentration(py::module& m) {
+    m.def("cube2mat_rv_gini_concentration", &cube2mat_rv_gini_concentration,
+          py::arg("result"), py::arg("cubes_map"),
+          "Gini concentration of realized variance contributions.");
+}

--- a/cpp_features/total_variation_close.cpp
+++ b/cpp_features/total_variation_close.cpp
@@ -1,0 +1,54 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <cmath>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_total_variation_close(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                    const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            double path = 0.0;
+            float prev = price_ptr[base];
+            bool prev_valid = std::isfinite(prev);
+            for (ssize_t t = 1; t < d2; ++t) {
+                float c = price_ptr[base + t];
+                bool cv = std::isfinite(c);
+                if (prev_valid && cv) path += std::fabs(static_cast<double>(c - prev));
+                prev = c;
+                prev_valid = cv;
+            }
+            res_ptr[i * d1 + j] = path > 0.0 ? static_cast<float>(path)
+                                             : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_total_variation_close(py::module& m) {
+    m.def("cube2mat_total_variation_close", &cube2mat_total_variation_close,
+          py::arg("result"), py::arg("cubes_map"),
+          "Total variation of close path.");
+}

--- a/cpp_features/trade_size_gini.cpp
+++ b/cpp_features/trade_size_gini.cpp
@@ -1,0 +1,50 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "common.hpp"
+#include <vector>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_trade_size_gini(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                              const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_volume")) {
+        throw std::runtime_error("cubes_map must contain 'interval_volume'");
+    }
+    auto vol_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto vbuf = vol_arr.request();
+    if (vbuf.ndim != 3) {
+        throw std::runtime_error("interval_volume must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = vbuf.shape[0];
+    const ssize_t d1 = vbuf.shape[1];
+    const ssize_t d2 = vbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match volume leading dims");
+    }
+    const float* vol_ptr = static_cast<float*>(vbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> ts;
+            ts.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                if (std::isfinite(v) && v >= 0.0f) ts.push_back(v);
+            }
+            res_ptr[i * d1 + j] = gini_coeff(ts);
+        }
+    }
+}
+
+void bind_trade_size_gini(py::module& m) {
+    m.def("cube2mat_trade_size_gini", &cube2mat_trade_size_gini,
+          py::arg("result"), py::arg("cubes_map"),
+          "Gini of per-bar average trade size (approximation).");
+}

--- a/cpp_features/trend_resid_kurt.cpp
+++ b/cpp_features/trend_resid_kurt.cpp
@@ -1,0 +1,96 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <vector>
+#include <limits>
+#include <cmath>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_trend_resid_kurt(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                               const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match last_price leading dims");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<double> y;
+            y.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = price_ptr[base + t];
+                if (std::isfinite(v)) y.push_back(v);
+            }
+            const ssize_t n = static_cast<ssize_t>(y.size());
+            if (n < 4) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double S_t = 0.0, S_y = 0.0, S_tt = 0.0, S_ty = 0.0;
+            for (ssize_t t = 0; t < n; ++t) {
+                double tt = static_cast<double>(t) / (n - 1);
+                double yy = y[t];
+                S_t += tt;
+                S_y += yy;
+                S_tt += tt * tt;
+                S_ty += tt * yy;
+            }
+            double denom = static_cast<double>(n) * S_tt - S_t * S_t;
+            if (denom == 0.0) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double beta1 = (static_cast<double>(n) * S_ty - S_t * S_y) / denom;
+            double beta0 = (S_y - beta1 * S_t) / static_cast<double>(n);
+            std::vector<double> e(n);
+            for (ssize_t t = 0; t < n; ++t) {
+                double tt = static_cast<double>(t) / (n - 1);
+                e[t] = y[t] - (beta0 + beta1 * tt);
+            }
+            double m = 0.0;
+            for (double v : e) m += v;
+            m /= static_cast<double>(n);
+            double c2 = 0.0, c4 = 0.0;
+            for (double v : e) {
+                double d = v - m;
+                double d2 = d * d;
+                c2 += d2;
+                c4 += d2 * d2;
+            }
+            c2 /= static_cast<double>(n);
+            c4 /= static_cast<double>(n);
+            if (!(c2 > 0.0)) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double g2 = c4 / (c2 * c2) - 3.0;
+            double adj = ((static_cast<double>(n) - 1) / ((n - 2.0) * (n - 3.0))) *
+                         ((n + 1.0) * g2 + 6.0);
+            res_ptr[i * d1 + j] = std::isfinite(adj) ? static_cast<float>(adj)
+                                                    : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_trend_resid_kurt(py::module& m) {
+    m.def("cube2mat_trend_resid_kurt", &cube2mat_trend_resid_kurt,
+          py::arg("result"), py::arg("cubes_map"),
+          "Adjusted excess kurtosis of trend residuals.");
+}

--- a/cpp_features/trend_resid_skew.cpp
+++ b/cpp_features/trend_resid_skew.cpp
@@ -1,0 +1,96 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <vector>
+#include <limits>
+#include <cmath>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_trend_resid_skew(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                               const py::dict& cubes_map) {
+    if (!cubes_map.contains("last_price")) {
+        throw std::runtime_error("cubes_map must contain 'last_price'");
+    }
+    auto price_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["last_price"]);
+    auto pbuf = price_arr.request();
+    if (pbuf.ndim != 3) {
+        throw std::runtime_error("last_price must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = pbuf.shape[0];
+    const ssize_t d1 = pbuf.shape[1];
+    const ssize_t d2 = pbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match last_price leading dims");
+    }
+    const float* price_ptr = static_cast<float*>(pbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<double> y;
+            y.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = price_ptr[base + t];
+                if (std::isfinite(v)) y.push_back(v);
+            }
+            const ssize_t n = static_cast<ssize_t>(y.size());
+            if (n < 3) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double S_t = 0.0, S_y = 0.0, S_tt = 0.0, S_ty = 0.0;
+            for (ssize_t t = 0; t < n; ++t) {
+                double tt = static_cast<double>(t) / (n - 1);
+                double yy = y[t];
+                S_t += tt;
+                S_y += yy;
+                S_tt += tt * tt;
+                S_ty += tt * yy;
+            }
+            double denom = static_cast<double>(n) * S_tt - S_t * S_t;
+            if (denom == 0.0) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double beta1 = (static_cast<double>(n) * S_ty - S_t * S_y) / denom;
+            double beta0 = (S_y - beta1 * S_t) / static_cast<double>(n);
+            std::vector<double> e(n);
+            for (ssize_t t = 0; t < n; ++t) {
+                double tt = static_cast<double>(t) / (n - 1);
+                e[t] = y[t] - (beta0 + beta1 * tt);
+            }
+            double m = 0.0;
+            for (double v : e) m += v;
+            m /= static_cast<double>(n);
+            double c2 = 0.0, c3 = 0.0;
+            for (double v : e) {
+                double d = v - m;
+                double d2 = d * d;
+                c2 += d2;
+                c3 += d2 * d;
+            }
+            c2 /= static_cast<double>(n);
+            c3 /= static_cast<double>(n);
+            if (!(c2 > 0.0)) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double g1 = c3 / std::pow(c2, 1.5);
+            double adj = std::sqrt(static_cast<double>(n) * (n - 1.0)) / (n - 2.0);
+            double val = adj * g1;
+            res_ptr[i * d1 + j] = std::isfinite(val) ? static_cast<float>(val)
+                                                     : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_trend_resid_skew(py::module& m) {
+    m.def("cube2mat_trend_resid_skew", &cube2mat_trend_resid_skew,
+          py::arg("result"), py::arg("cubes_map"),
+          "Adjusted skewness of trend residuals.");
+}

--- a/cpp_features/volume_entropy_concentration.cpp
+++ b/cpp_features/volume_entropy_concentration.cpp
@@ -1,0 +1,50 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "common.hpp"
+#include <vector>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_volume_entropy_concentration(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                           const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_volume")) {
+        throw std::runtime_error("cubes_map must contain 'interval_volume'");
+    }
+    auto vol_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto vbuf = vol_arr.request();
+    if (vbuf.ndim != 3) {
+        throw std::runtime_error("interval_volume must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = vbuf.shape[0];
+    const ssize_t d1 = vbuf.shape[1];
+    const ssize_t d2 = vbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match volume leading dims");
+    }
+    const float* vol_ptr = static_cast<float*>(vbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> vals;
+            vals.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                if (std::isfinite(v) && v > 0.0f) vals.push_back(v);
+            }
+            res_ptr[i * d1 + j] = entropy_concentration(vals);
+        }
+    }
+}
+
+void bind_volume_entropy_concentration(py::module& m) {
+    m.def("cube2mat_volume_entropy_concentration", &cube2mat_volume_entropy_concentration,
+          py::arg("result"), py::arg("cubes_map"),
+          "1 - normalized entropy of volume distribution.");
+}

--- a/cpp_features/volume_gini.cpp
+++ b/cpp_features/volume_gini.cpp
@@ -1,0 +1,50 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "common.hpp"
+#include <vector>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_volume_gini(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                          const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_volume")) {
+        throw std::runtime_error("cubes_map must contain 'interval_volume'");
+    }
+    auto vol_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto vbuf = vol_arr.request();
+    if (vbuf.ndim != 3) {
+        throw std::runtime_error("interval_volume must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = vbuf.shape[0];
+    const ssize_t d1 = vbuf.shape[1];
+    const ssize_t d2 = vbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match volume leading dims");
+    }
+    const float* vol_ptr = static_cast<float*>(vbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> vals;
+            vals.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                if (std::isfinite(v) && v >= 0.0f) vals.push_back(v);
+            }
+            res_ptr[i * d1 + j] = gini_coeff(vals);
+        }
+    }
+}
+
+void bind_volume_gini(py::module& m) {
+    m.def("cube2mat_volume_gini", &cube2mat_volume_gini,
+          py::arg("result"), py::arg("cubes_map"),
+          "Gini index of per-bar volume distribution.");
+}

--- a/cpp_features/volume_median_to_mean_ratio.cpp
+++ b/cpp_features/volume_median_to_mean_ratio.cpp
@@ -1,0 +1,71 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <vector>
+#include <limits>
+#include <algorithm>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_volume_median_to_mean_ratio(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                          const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_volume")) {
+        throw std::runtime_error("cubes_map must contain 'interval_volume'");
+    }
+    auto vol_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto vbuf = vol_arr.request();
+    if (vbuf.ndim != 3) {
+        throw std::runtime_error("interval_volume must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = vbuf.shape[0];
+    const ssize_t d1 = vbuf.shape[1];
+    const ssize_t d2 = vbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match volume leading dims");
+    }
+    const float* vol_ptr = static_cast<float*>(vbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<float> vals;
+            vals.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                if (std::isfinite(v) && v >= 0.0f) vals.push_back(v);
+            }
+            const ssize_t n = static_cast<ssize_t>(vals.size());
+            if (n == 0) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double mean = 0.0;
+            for (float v : vals) mean += v;
+            mean /= static_cast<double>(n);
+            if (!(mean > 0.0)) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            std::sort(vals.begin(), vals.end());
+            double median;
+            if (n % 2 == 1) {
+                median = vals[n / 2];
+            } else {
+                median = 0.5 * (vals[n / 2 - 1] + vals[n / 2]);
+            }
+            double ratio = median / mean;
+            res_ptr[i * d1 + j] = std::isfinite(ratio) ? static_cast<float>(ratio)
+                                                       : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_volume_median_to_mean_ratio(py::module& m) {
+    m.def("cube2mat_volume_median_to_mean_ratio", &cube2mat_volume_median_to_mean_ratio,
+          py::arg("result"), py::arg("cubes_map"),
+          "Median-to-mean ratio of volume.");
+}

--- a/cpp_features/volume_skew.cpp
+++ b/cpp_features/volume_skew.cpp
@@ -1,0 +1,73 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <vector>
+#include <limits>
+#include <cmath>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_volume_skew(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                          const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_volume")) {
+        throw std::runtime_error("cubes_map must contain 'interval_volume'");
+    }
+    auto vol_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto vbuf = vol_arr.request();
+    if (vbuf.ndim != 3) {
+        throw std::runtime_error("interval_volume must be 3D array (d0,d1,d2)");
+    }
+    const ssize_t d0 = vbuf.shape[0];
+    const ssize_t d1 = vbuf.shape[1];
+    const ssize_t d2 = vbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match volume leading dims");
+    }
+    const float* vol_ptr = static_cast<float*>(vbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            std::vector<double> vals;
+            vals.reserve(d2);
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                if (std::isfinite(v)) vals.push_back(v);
+            }
+            const ssize_t n = static_cast<ssize_t>(vals.size());
+            if (n < 3) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double mean = 0.0;
+            for (double v : vals) mean += v;
+            mean /= static_cast<double>(n);
+            double m2 = 0.0, m3 = 0.0;
+            for (double v : vals) {
+                double d = v - mean;
+                m2 += d * d;
+                m3 += d * d * d;
+            }
+            double s2 = m2 / static_cast<double>(n - 1);
+            if (!(s2 > 0.0)) {
+                res_ptr[i * d1 + j] = std::numeric_limits<float>::quiet_NaN();
+                continue;
+            }
+            double s = std::sqrt(s2);
+            double m3_mean = m3 / static_cast<double>(n);
+            double g1 = m3_mean / (s * s * s);
+            res_ptr[i * d1 + j] = std::isfinite(g1) ? static_cast<float>(g1)
+                                                    : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_volume_skew(py::module& m) {
+    m.def("cube2mat_volume_skew", &cube2mat_volume_skew,
+          py::arg("result"), py::arg("cubes_map"),
+          "Skewness of volume distribution.");
+}

--- a/cpp_features/vwap.cpp
+++ b/cpp_features/vwap.cpp
@@ -1,0 +1,69 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <cmath>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_vwap(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                   const py::dict& cubes_map) {
+    if (!cubes_map.contains("close") || !cubes_map.contains("volume")) {
+        throw std::runtime_error("cubes_map must contain 'close' and 'volume'");
+    }
+
+    auto close_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["close"]);
+    auto volume_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["volume"]);
+
+    auto cbuf = close_arr.request();
+    auto vbuf = volume_arr.request();
+    if (cbuf.ndim != 3 || vbuf.ndim != 3) {
+        throw std::runtime_error("close and volume must be 3D arrays of shape (d0,d1,d2)");
+    }
+    if (cbuf.shape[0] != vbuf.shape[0] || cbuf.shape[1] != vbuf.shape[1] || cbuf.shape[2] != vbuf.shape[2]) {
+        throw std::runtime_error("close and volume must have the same shape");
+    }
+
+    const ssize_t d0 = cbuf.shape[0];
+    const ssize_t d1 = cbuf.shape[1];
+    const ssize_t d2 = cbuf.shape[2];
+
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1) and match close/volume leading dims");
+    }
+
+    const float* close_ptr  = static_cast<float*>(cbuf.ptr);
+    const float* volume_ptr = static_cast<float*>(vbuf.ptr);
+    float* res_ptr          = static_cast<float*>(rbuf.ptr);
+
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+
+            float num = 0.0f;
+            float den = 0.0f;
+
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = volume_ptr[base + t];
+                float c = close_ptr [base + t];
+                if (std::isnan(v) || std::isnan(c) || !(v > 0.0f)) continue;
+                num += c * v;
+                den += v;
+            }
+
+            res_ptr[i * d1 + j] = (den > 0.0f)
+                ? (num / den)
+                : std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+void bind_cube2mat_vwap(py::module& m) {
+    m.def("cube2mat_vwap", &cube2mat_vwap,
+          py::arg("result"), py::arg("cubes_map"),
+          "Compute VWAP over all timesteps for each (i,j).");
+}

--- a/cpp_features/vwap_position_in_range.cpp
+++ b/cpp_features/vwap_position_in_range.cpp
@@ -1,0 +1,70 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <limits>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace py = pybind11;
+
+void cube2mat_vwap_position_in_range(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
+                                     const py::dict& cubes_map) {
+    if (!cubes_map.contains("interval_vwap") || !cubes_map.contains("interval_volume") || !cubes_map.contains("interval_high") || !cubes_map.contains("interval_low")) {
+        throw std::runtime_error("cubes_map must contain 'interval_vwap','interval_volume','interval_high','interval_low'");
+    }
+    auto vwap_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_vwap"]);
+    auto vol_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_volume"]);
+    auto high_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_high"]);
+    auto low_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["interval_low"]);
+    auto vwbuf = vwap_arr.request();
+    auto vbuf = vol_arr.request();
+    auto hbuf = high_arr.request();
+    auto lbuf = low_arr.request();
+    if (vwbuf.ndim != 3 || vbuf.ndim != 3 || hbuf.ndim != 3 || lbuf.ndim != 3) {
+        throw std::runtime_error("inputs must be 3D arrays");
+    }
+    const ssize_t d0 = vwbuf.shape[0];
+    const ssize_t d1 = vwbuf.shape[1];
+    const ssize_t d2 = vwbuf.shape[2];
+    auto rbuf = result.request();
+    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
+        throw std::runtime_error("result must be 2D (d0,d1)");
+    }
+    const float* vwap_ptr = static_cast<float*>(vwbuf.ptr);
+    const float* vol_ptr  = static_cast<float*>(vbuf.ptr);
+    const float* high_ptr = static_cast<float*>(hbuf.ptr);
+    const float* low_ptr  = static_cast<float*>(lbuf.ptr);
+    float* res_ptr = static_cast<float*>(rbuf.ptr);
+    #pragma omp parallel for collapse(2)
+    for (ssize_t i = 0; i < d0; ++i) {
+        for (ssize_t j = 0; j < d1; ++j) {
+            const ssize_t base = i * (d1 * d2) + j * d2;
+            double num = 0.0, den = 0.0;
+            float high = high_ptr[base];
+            float low  = low_ptr[base];
+            for (ssize_t t = 0; t < d2; ++t) {
+                float v = vol_ptr[base + t];
+                float w = vwap_ptr[base + t];
+                float h = high_ptr[base + t];
+                float l = low_ptr[base + t];
+                if (std::isfinite(v) && v > 0.0f && std::isfinite(w)) {
+                    num += w * v;
+                    den += v;
+                }
+                if (std::isfinite(h) && h > high) high = h;
+                if (std::isfinite(l) && l < low)  low  = l;
+            }
+            float vwap = (den > 0.0) ? static_cast<float>(num / den) : std::numeric_limits<float>::quiet_NaN();
+            float range = high - low;
+            float val = (std::isfinite(vwap) && range > 0.0f) ? (vwap - low) / range
+                                                              : std::numeric_limits<float>::quiet_NaN();
+            res_ptr[i * d1 + j] = val;
+        }
+    }
+}
+
+void bind_vwap_position_in_range(py::module& m) {
+    m.def("cube2mat_vwap_position_in_range", &cube2mat_vwap_position_in_range,
+          py::arg("result"), py::arg("cubes_map"),
+          "Position of session VWAP within range.");
+}

--- a/machine_alpha.cpp
+++ b/machine_alpha.cpp
@@ -1,74 +1,58 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
-#include <cmath>
-#include <limits>
-#ifdef _OPENMP
-#include <omp.h>
-#endif
 
 namespace py = pybind11;
 
-// 计算 VWAP: sum(close*volume) / sum(volume)
-// 输入: cubes_map["close"], cubes_map["volume"] (float32, shape=(d0,d1,d2))
-// 输出: result (float32, shape=(d0,d1))
-void cube2mat_vwap(py::array_t<float, py::array::c_style | py::array::forcecast>& result,
-                   const py::dict& cubes_map) {
-    if (!cubes_map.contains("close") || !cubes_map.contains("volume")) {
-        throw std::runtime_error("cubes_map must contain 'close' and 'volume'");
-    }
-
-    auto close_arr  = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["close"]);
-    auto volume_arr = py::cast<py::array_t<float, py::array::c_style | py::array::forcecast>>(cubes_map["volume"]);
-
-    auto cbuf = close_arr.request();
-    auto vbuf = volume_arr.request();
-    if (cbuf.ndim != 3 || vbuf.ndim != 3) {
-        throw std::runtime_error("close and volume must be 3D arrays of shape (d0,d1,d2)");
-    }
-    if (cbuf.shape[0] != vbuf.shape[0] || cbuf.shape[1] != vbuf.shape[1] || cbuf.shape[2] != vbuf.shape[2]) {
-        throw std::runtime_error("close and volume must have the same shape");
-    }
-
-    const ssize_t d0 = cbuf.shape[0];
-    const ssize_t d1 = cbuf.shape[1];
-    const ssize_t d2 = cbuf.shape[2];
-
-    auto rbuf = result.request();
-    if (rbuf.ndim != 2 || rbuf.shape[0] != d0 || rbuf.shape[1] != d1) {
-        throw std::runtime_error("result must be 2D (d0,d1) and match close/volume leading dims");
-    }
-
-    const float* close_ptr  = static_cast<float*>(cbuf.ptr);
-    const float* volume_ptr = static_cast<float*>(vbuf.ptr);
-    float* res_ptr          = static_cast<float*>(rbuf.ptr);
-
-    // 索引: idx(i,j,t) = i*(d1*d2) + j*d2 + t
-    #pragma omp parallel for collapse(2)
-    for (ssize_t i = 0; i < d0; ++i) {
-        for (ssize_t j = 0; j < d1; ++j) {
-            const ssize_t base = i * (d1 * d2) + j * d2;
-
-            float num = 0.0f;  // sum(close*volume)
-            float den = 0.0f;  // sum(volume)
-
-            for (ssize_t t = 0; t < d2; ++t) {
-                float v = volume_ptr[base + t];
-                float c = close_ptr [base + t];
-                if (std::isnan(v) || std::isnan(c) || !(v > 0.0f)) continue;
-                num += c * v;
-                den += v;
-            }
-
-            res_ptr[i * d1 + j] = (den > 0.0f)
-                ? (num / den)
-                : std::numeric_limits<float>::quiet_NaN();
-        }
-    }
-}
+void bind_cube2mat_vwap(py::module& m);
+void bind_gini_absret(py::module& m);
+void bind_n_entropy_concentration(py::module& m);
+void bind_n_gini(py::module& m);
+void bind_ret_skew(py::module& m);
+void bind_rv_entropy_concentration(py::module& m);
+void bind_rv_gini_concentration(py::module& m);
+void bind_trade_size_gini(py::module& m);
+void bind_trend_resid_kurt(py::module& m);
+void bind_trend_resid_skew(py::module& m);
+void bind_volume_entropy_concentration(py::module& m);
+void bind_volume_gini(py::module& m);
+void bind_volume_median_to_mean_ratio(py::module& m);
+void bind_volume_skew(py::module& m);
+void bind_katz_fd_close(py::module& m);
+void bind_oc_efficiency_over_range(py::module& m);
+void bind_path_efficiency(py::module& m);
+void bind_path_length_over_range(py::module& m);
+void bind_total_variation_close(py::module& m);
+void bind_close_to_edge_distance_frac(py::module& m);
+void bind_end_position_in_range(py::module& m);
+void bind_intraday_max_drawdown_close(py::module& m);
+void bind_parkinson_vol(py::module& m);
+void bind_range_per_trade(py::module& m);
+void bind_vwap_position_in_range(py::module& m);
 
 PYBIND11_MODULE(machine_alpha, m) {
-    m.doc() = "fast VWAP feature";
-    m.def("cube2mat_vwap", &cube2mat_vwap,
-          py::arg("result"), py::arg("cubes_map"),
-          "Compute VWAP over all timesteps for each (i,j).");
+    m.doc() = "collection of intraday features";
+    bind_cube2mat_vwap(m);
+    bind_gini_absret(m);
+    bind_n_entropy_concentration(m);
+    bind_n_gini(m);
+    bind_ret_skew(m);
+    bind_rv_entropy_concentration(m);
+    bind_rv_gini_concentration(m);
+    bind_trade_size_gini(m);
+    bind_trend_resid_kurt(m);
+    bind_trend_resid_skew(m);
+    bind_volume_entropy_concentration(m);
+    bind_volume_gini(m);
+    bind_volume_median_to_mean_ratio(m);
+    bind_volume_skew(m);
+    bind_katz_fd_close(m);
+    bind_oc_efficiency_over_range(m);
+    bind_path_efficiency(m);
+    bind_path_length_over_range(m);
+    bind_total_variation_close(m);
+    bind_close_to_edge_distance_frac(m);
+    bind_end_position_in_range(m);
+    bind_intraday_max_drawdown_close(m);
+    bind_parkinson_vol(m);
+    bind_range_per_trade(m);
+    bind_vwap_position_in_range(m);
 }


### PR DESCRIPTION
## Summary
- split `machine_alpha.cpp` into a lightweight binder and individual feature implementations under `cpp_features`
- add separate C++ sources for path, range, and distribution metrics, each with its own pybind binding function

## Testing
- `g++ -std=c++17 -fPIC -shared -I/usr/include/python3.11 -I/usr/local/lib/python3.11/site-packages/pybind11/include machine_alpha.cpp cpp_features/*.cpp -o machine_alpha.so` *(fails: pybind11/pybind11.h: No such file or directory)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b86555ce708325b3c31023d5c3b5ed